### PR TITLE
Ability to specify busybox image for etcd init containers

### DIFF
--- a/cilium-etcd-cluster/descriptors.go
+++ b/cilium-etcd-cluster/descriptors.go
@@ -24,7 +24,7 @@ import (
 
 // CiliumEtcdCluster returns a Cilium ETCD cluster on the given namespace
 // for the given etcd version with for the given size.
-func CiliumEtcdCluster(namespace, repository, version string, size int, etcdEnv []v1.EnvVar, affinity *v1.Affinity, nodeSelector map[string]string) *v1beta2.EtcdCluster {
+func CiliumEtcdCluster(namespace, repository, version string, size int, etcdEnv []v1.EnvVar, affinity *v1.Affinity, nodeSelector map[string]string, busyboxImage string) *v1beta2.EtcdCluster {
 	var etcdNodeSelector map[string]string
 	if len(nodeSelector) != 0 {
 		etcdNodeSelector = nodeSelector
@@ -51,7 +51,7 @@ func CiliumEtcdCluster(namespace, repository, version string, size int, etcdEnv 
 			Pod: &v1beta2.PodPolicy{
 				EtcdEnv:      etcdEnv,
 				Labels:       defaults.CiliumLabelsApp,
-				BusyboxImage: "docker.io/library/busybox:1.28.0-glibc",
+				BusyboxImage: busyboxImage,
 				Affinity:     affinity,
 				NodeSelector: etcdNodeSelector,
 			},

--- a/main.go
+++ b/main.go
@@ -96,6 +96,7 @@ var (
 	etcdImageRepository     string
 	generateCerts           bool
 	cleanUpOnExit           bool
+	busyboxImage            string
 	operatorImage           string
 	operatorImagePullSecret string
 
@@ -139,6 +140,9 @@ func init() {
 	flags.BoolVar(&cleanUpOnExit,
 		"cleanup", true, "Cleanup resources on exit")
 	viper.BindEnv("cleanup", "CILIUM_ETCD_OPERATOR_CLEANUP")
+	flags.StringVar(&busyboxImage,
+		"busybox-image", defaults.DefaultBusyboxImage, "Busybox image used for ETCD init container")
+	viper.BindEnv("busybox-image", "CILIUM_ETCD_BUSYBOX_IMAGE")
 	flags.StringVar(&operatorImage,
 		"operator-image", defaults.DefaultOperatorImage, "Etcd Operator Image to be used")
 	viper.BindEnv("operator-image", "CILIUM_ETCD_OPERATOR_IMAGE")
@@ -215,7 +219,7 @@ func parseFlags() {
 
 	etcdCRD = etcd_operator.EtcdCRD()
 	etcdDeployment = etcd_operator.EtcdOperatorDeployment(namespace, ownerName, ownerUID, operatorImage, operatorImagePullSecret)
-	ciliumEtcdCR = cilium_etcd_cluster.CiliumEtcdCluster(namespace, etcdImageRepository, etcdVersion, clusterSize, etcdEnvVar, affinity, etcdNodeSelector)
+	ciliumEtcdCR = cilium_etcd_cluster.CiliumEtcdCluster(namespace, etcdImageRepository, etcdVersion, clusterSize, etcdEnvVar, affinity, etcdNodeSelector, busyboxImage)
 	gracePeriod = time.Duration(gracePeriodSec) * time.Second
 }
 

--- a/pkg/defaults/const.go
+++ b/pkg/defaults/const.go
@@ -30,6 +30,8 @@ var (
 
 	DefaultOperatorImage = "quay.io/coreos/etcd-operator:v0.9.3"
 
+	DefaultBusyboxImage = "docker.io/library/busybox:1.28.0-glibc"
+
 	DefaultNamespace = "kube-system"
 
 	ClusterDomain = "cluster.local"


### PR DESCRIPTION
As requested in Slack this PR adds the ability to specify the busybox image of the etcd init container.

The change is fairly simple and introduces a flag and env variable to override the default busybox image.